### PR TITLE
Feature: better repr methods

### DIFF
--- a/vectorlink-hnsw-python/src/lib.rs
+++ b/vectorlink-hnsw-python/src/lib.rs
@@ -114,6 +114,10 @@ impl Vectors {
     pub fn load(dirpath: &str, identity: &str) -> PyResult<Self> {
         Ok(Self(vectors::Vectors::load(dirpath, identity)?))
     }
+
+    pub fn __repr__(&self) -> String {
+        format!("{:#?}", self.0)
+    }
 }
 
 // PyO3 / Maturin require that no generics are used at FFI boundaries.
@@ -129,7 +133,7 @@ macro_rules! wrap_SimdAlignedAllocation_type_for_element {
         paste::paste! {
             $(
                 #[pyclass(module = "vectorlink_hnsw")]
-                #[derive(Clone)]
+                #[derive(Clone, Debug)]
                 pub struct [<SimdAlignedAllocation $element:upper>](
                     util::SimdAlignedAllocation<$element>
                 );
@@ -157,6 +161,10 @@ macro_rules! wrap_SimdAlignedAllocation_type_for_element {
                             default_value
                         ))
                     }
+
+                    pub fn __repr__(&self) -> String {
+                        format!("{:#?}", self.0)
+                    }
                 }
             )*
         }
@@ -170,6 +178,13 @@ wrap_SimdAlignedAllocation_type_for_element![u8];
 #[allow(unused)]
 #[pyclass(module = "vectorlink_hnsw")]
 pub struct LayerMetadata(serialize::LayerMetadata);
+
+#[pymethods]
+impl LayerMetadata {
+    pub fn __repr__(&self) -> String {
+        format!("{:#?}", self.0)
+    }
+}
 
 #[pyclass(module = "vectorlink_hnsw")]
 #[derive(Clone)]
@@ -217,7 +232,12 @@ impl Layer {
             layer_index,
         )?))
     }
+
+    pub fn __repr__(&self) -> String {
+        format!("{:#?}", self.0)
+    }
 }
+
 
 #[pyclass(module = "vectorlink_hnsw")]
 pub struct HnswMetadata(serialize::HnswMetadata);
@@ -226,6 +246,10 @@ pub struct HnswMetadata(serialize::HnswMetadata);
 impl HnswMetadata {
     pub fn layer_count(&self) -> usize {
         self.0.layer_count()
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("{:#?}", self.0)
     }
 }
 
@@ -319,11 +343,21 @@ impl Hnsw {
     pub fn load(dirpath: &str) -> PyResult<Self> {
         Ok(Self(hnsw::Hnsw::load(dirpath)?))
     }
+
+    pub fn __repr__(&self) -> String {
+        format!("{:#?}", self.0)
+    }
 }
 
 #[allow(unused)]
 #[pyclass(module = "vectorlink_hnsw")]
 pub struct HnswType(serialize::HnswType);
+
+impl HnswType {
+    pub fn __repr__(&self) -> String {
+        format!("{:#?}", self.0)
+    }
+}
 
 macro_rules! wrap_index_type {
     ($($type:ident),* $(,)?) => {
@@ -348,6 +382,10 @@ macro_rules! wrap_index_type {
 
                 pub fn store_hnsw(&self, hnsw_dirpath: &str) -> PyResult<()> {
                     Ok(self.0.store_hnsw(hnsw_dirpath)?)
+                }
+
+                pub fn __repr__(&self) -> String {
+                    format!("{:#?}", self.0)
                 }
             }
         )*
@@ -398,6 +436,10 @@ impl BuildParams {
     pub fn default() -> Self {
         Self::from(params::BuildParams::default())
     }
+
+    pub fn __repr__(&self) -> String {
+        format!("{:#?}", self)
+    }
 }
 
 impl From<params::BuildParams> for BuildParams {
@@ -427,6 +469,10 @@ impl OptimizationParams {
     #[staticmethod]
     pub fn default() -> Self {
         Self::from(params::OptimizationParams::default())
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("{:#?}", self)
     }
 }
 
@@ -468,6 +514,10 @@ impl SearchParams {
     #[staticmethod]
     pub fn default() -> Self {
         Self::from(params::SearchParams::default())
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("{:#?}", self)
     }
 }
 

--- a/vectorlink-hnsw-python/src/lib.rs
+++ b/vectorlink-hnsw-python/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(unexpected_cfgs)]
-
 use ::vectorlink_hnsw::{
     comparator::CosineDistance1536, hnsw, index, layer, params, serialize,
     util, vectors,

--- a/vectorlink-hnsw/src/hnsw.rs
+++ b/vectorlink-hnsw/src/hnsw.rs
@@ -10,6 +10,7 @@ use crate::{
 use rand::prelude::*;
 use rayon::prelude::*;
 
+#[derive(Debug)]
 pub struct Hnsw {
     layers: Vec<Layer>,
 }

--- a/vectorlink-hnsw/src/index.rs
+++ b/vectorlink-hnsw/src/index.rs
@@ -66,6 +66,7 @@ pub trait NewIndex: Index {
     fn generate(vectors: Vectors, bp: &BuildParams) -> Self;
 }
 
+#[derive(Debug)]
 pub struct Pq1024x8 {
     pq: Pq,
     vectors: Vectors,
@@ -79,18 +80,21 @@ impl Pq1024x8 {
     }
 }
 
+#[derive(Debug)]
 pub struct Hnsw1024 {
     hnsw: Hnsw,
     vectors: Vectors,
     name: String,
 }
 
+#[derive(Debug)]
 pub struct Hnsw1536 {
     hnsw: Hnsw,
     vectors: Vectors,
     name: String,
 }
 
+#[derive(Debug)]
 #[enum_dispatch(Index)]
 pub enum IndexConfiguration {
     Hnsw1024(Hnsw1024),

--- a/vectorlink-hnsw/src/layer.rs
+++ b/vectorlink-hnsw/src/layer.rs
@@ -39,7 +39,7 @@ impl Ord for OrderedFloat {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Layer {
     neighborhoods: SimdAlignedAllocation<u32>,
     single_neighborhood_size: usize,

--- a/vectorlink-hnsw/src/memoize.rs
+++ b/vectorlink-hnsw/src/memoize.rs
@@ -73,6 +73,7 @@ pub trait CentroidDistanceCalculatorConstructor {
     fn new(vectors: &Vectors) -> Self::Calculator<'_>;
 }
 
+#[derive(Debug)]
 pub struct MemoizedCentroidDistances {
     dot_products: Vec<f16>,
     norms: Vec<f16>,

--- a/vectorlink-hnsw/src/pq.rs
+++ b/vectorlink-hnsw/src/pq.rs
@@ -18,6 +18,7 @@ use crate::{
     vectors::{Vector, Vectors},
 };
 
+#[derive(Debug)]
 pub struct Pq {
     centroids: Vectors,
     pub quantized_vectors: Vectors,
@@ -121,6 +122,7 @@ pub fn centroid_finder<V: VectorRangeIndexable>(
 
 pub struct CentroidConstructor1024x8;
 
+#[derive(Debug)]
 pub struct Quantizer {
     hnsw: Hnsw,
     sp: SearchParams,

--- a/vectorlink-hnsw/src/serialize.rs
+++ b/vectorlink-hnsw/src/serialize.rs
@@ -158,7 +158,7 @@ impl Vectors {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LayerMetadata {
     single_neighborhood_size: usize,
 }
@@ -334,7 +334,7 @@ impl Layer {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HnswMetadata {
     layer_count: usize,
 }

--- a/vectorlink-hnsw/src/util.rs
+++ b/vectorlink-hnsw/src/util.rs
@@ -17,6 +17,35 @@ pub struct SimdAlignedAllocation<T: SimdElement> {
     _owned: PhantomData<T>,
 }
 
+impl<T: SimdElement> std::fmt::Debug for SimdAlignedAllocation<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+
+        unsafe fn fmt_as_array(
+            ptr: &NonNull<u8>,
+            len: usize,
+        ) -> Result<String, std::fmt::Error> {
+            use std::fmt::Write;
+            let mut buf = String::new();
+            write!(buf, "[")?;
+            for i in 0..len {
+                if i > 0 {
+                    write!(buf, ", ")?;
+                }
+                write!(buf, "{}", ptr.offset(i as isize).as_ref())?;
+            }
+            write!(buf, "]")?;
+            Ok(buf)
+        }
+
+        f.debug_struct("SimdAlignedAllocation")
+            .field("data", unsafe { self.data.as_ref() })
+            .field("*data", unsafe { &fmt_as_array(&self.data, self.len)? })
+            .field("len", &self.len)
+            .field("_owned", &self._owned)
+            .finish()
+    }
+}
+
 unsafe impl<T: SimdElement> Send for SimdAlignedAllocation<T> {}
 unsafe impl<T: SimdElement> Sync for SimdAlignedAllocation<T> {}
 

--- a/vectorlink-hnsw/src/util.rs
+++ b/vectorlink-hnsw/src/util.rs
@@ -6,6 +6,7 @@ use std::{
     simd::{LaneCount, Simd, SimdElement, SupportedLaneCount},
 };
 
+#[derive(Debug)]
 /// Align allocations to be rust simd friendly.
 /// The biggest possible simd abstration is f64x64, which is 512 bytes. So this
 /// will make sure we're aligned to that, allowing simd instructions over the
@@ -15,35 +16,6 @@ pub struct SimdAlignedAllocation<T: SimdElement> {
     data: NonNull<u8>,
     len: usize,
     _owned: PhantomData<T>,
-}
-
-impl<T: SimdElement> std::fmt::Debug for SimdAlignedAllocation<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-
-        unsafe fn fmt_as_array(
-            ptr: &NonNull<u8>,
-            len: usize,
-        ) -> Result<String, std::fmt::Error> {
-            use std::fmt::Write;
-            let mut buf = String::new();
-            write!(buf, "[")?;
-            for i in 0..len {
-                if i > 0 {
-                    write!(buf, ", ")?;
-                }
-                write!(buf, "{}", ptr.offset(i as isize).as_ref())?;
-            }
-            write!(buf, "]")?;
-            Ok(buf)
-        }
-
-        f.debug_struct("SimdAlignedAllocation")
-            .field("data", unsafe { self.data.as_ref() })
-            .field("*data", unsafe { &fmt_as_array(&self.data, self.len)? })
-            .field("len", &self.len)
-            .field("_owned", &self._owned)
-            .finish()
-    }
 }
 
 unsafe impl<T: SimdElement> Send for SimdAlignedAllocation<T> {}

--- a/vectorlink-hnsw/src/vectors.rs
+++ b/vectorlink-hnsw/src/vectors.rs
@@ -22,7 +22,7 @@ pub enum Vector<'a> {
 /// A slab of `N` vectors, where:
 ///   * each vector is aligned, and
 ///   * `N = data.len() / vector_byte_size`
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Vectors {
     data: SimdAlignedAllocation<u8>,
     vector_byte_size: usize,


### PR DESCRIPTION
This PR:
- Adds `__repr__()` methods for all types in `vectorlink-hnsw-python` that can cross the FFI boundary.
- Removes a now-obsolete `#![allow(unexpected_cfgs)]` module-level attribute